### PR TITLE
Fix GUI exception handling and add missing dependency

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -322,7 +322,8 @@ class PredictorGUI:
         except Exception as e:
             import traceback
             traceback.print_exc()
-            self.root.after(0, lambda: self._err(str(e)))
+            msg = str(e)
+            self.root.after(0, lambda: self._err(msg))
 
     def _tsts(self, t, c=TEXT_SEC):
         self.root.after(0, lambda: self._sts(t, c))

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ PyMuPDF>=1.24.0
 scikit-learn>=1.4.0
 scipy>=1.10.0
 numpy>=1.24.0
+sentence-transformers>=3.0.0
 
 # Image statistics
 Pillow>=10.0.0


### PR DESCRIPTION
This PR fixes a Tkinter callback issue in `gui.py` and adds a missing dependency.

Errors:
- NameError: cannot access free variable 'e'
- Missing sentence-transformers

Reasons:
The previous code referenced the exception variable 'e' inside a lambda passed to 'root.after()'. Since exception variables are cleared after the 'except' block, the callback could fail when executed later.